### PR TITLE
fix: Define param schema type when provided

### DIFF
--- a/src/generators/type-picker.js
+++ b/src/generators/type-picker.js
@@ -21,8 +21,13 @@ const api = {
       return generateDefinitionReference(param.$ref);
     }
 
-    if (param.schema && param.schema.$ref) {
-      return generateDefinitionReference(param.schema.$ref);
+    if (param.schema) {
+      if (param.schema.$ref) {
+        return generateDefinitionReference(param.schema.$ref);
+      }
+      else if (param.schema.type) {
+        return param.schema.type;
+      }
     }
 
     return 'unspecified type';

--- a/test/unit/type-picker-test.js
+++ b/test/unit/type-picker-test.js
@@ -47,6 +47,23 @@ describe('test/unit/type-picker-test.js', () => {
 
     });
 
+    describe('with param having schema with type', () => {
+      let param;
+
+      beforeEach(() => {
+        param = {
+          schema: {
+            type: 'object',
+          },
+        };
+      });
+
+      it('should return type of schema', () => {
+        type_picker.extractType(param).should.eql('object');
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
fix: Define param schema type when provided

E.g. extracts `object` in cases like:

```
{
  "param": {
    "schema": {
      "type": "object"
    }
  }
}
```
