### PR TITLE
Generate request params schema if provided

### DIFF
--- a/src/generators/path-generator.js
+++ b/src/generators/path-generator.js
@@ -45,10 +45,19 @@ function generateParameters(params) {
     return undefined;
   }
   const param_list_str = params.map(param => {
-    let value = `- ${param.in}: ${param.name} (${type_picker.extractType(param)}) - ${param.description}`;
+    const param_type = type_picker.extractType(param);
+    let value = `- ${param.in}: ${param.name} (${param_type}) - ${param.description}`;
 
     if (!param.required) {
       value += ' (optional)';
+    }
+
+    if (param.schema) {
+      const schema_definition = schema_generator.createSchemaList(param.schema);
+      const schema_definition_params = schema_definition.split('\n').slice(1).join('\n');
+      if (schema_definition_params.length) {
+        value += `\n${schema_definition_params}`;
+      }
     }
 
     return value;

--- a/src/generators/type-picker.js
+++ b/src/generators/type-picker.js
@@ -21,8 +21,13 @@ const api = {
       return generateDefinitionReference(param.$ref);
     }
 
-    if (param.schema && param.schema.$ref) {
-      return generateDefinitionReference(param.schema.$ref);
+    if (param.schema) {
+      if (param.schema.$ref) {
+        return generateDefinitionReference(param.schema.$ref);
+      }
+      else if (param.schema.type) {
+        return param.schema.type;
+      }
     }
 
     return 'unspecified type';

--- a/test-util/fixtures.js
+++ b/test-util/fixtures.js
@@ -9,7 +9,7 @@ const api = {
   },
 
   loadSwaggerSpecMarkdown(filename = 'pet-store.md') {
-    return fixture_loader.loadString('markdown', filename);
+    return fixture_loader.loadString('markdown', filename).trim();
   },
 
   loadResponseExample() {

--- a/test-util/fixtures/markdown/path/post-with-params.md
+++ b/test-util/fixtures/markdown/path/post-with-params.md
@@ -1,0 +1,24 @@
+### POST /pets
+
+Creates a new pet
+
+**Parameters**
+
+- body: body (object) - Params for new pet
+  - name (string)
+
+#### Response: 201
+
+pet response
+
+**Schema**
+
+- (Pet)
+
+#### Response: default
+
+unexpected error
+
+**Schema**
+
+- (Error)

--- a/test-util/fixtures/swagger/path/post-with-params.json
+++ b/test-util/fixtures/swagger/path/post-with-params.json
@@ -1,0 +1,40 @@
+{
+  "/pets": {
+    "post": {
+      "description": "Creates a new pet",
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "description": "Params for new pet",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        }
+      ],
+      "responses": {
+        "201": {
+          "description": "pet response",
+          "schema": {
+            "$ref": "#/definitions/Pet"
+          }
+        },
+        "default": {
+          "description": "unexpected error",
+          "schema": {
+            "$ref": "#/definitions/Error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/unit/path-generator-test.js
+++ b/test/unit/path-generator-test.js
@@ -21,8 +21,26 @@ describe('test/unit/path-generator-test.js', () => {
         const key = Object.keys(path_api_spec)[0];
         const markdown_str = generator.generatePath(key, path_api_spec[key]);
         markdown_str.should.eql(swagger_api_md_str);
-        const markdown_str_with_added_newline = `${markdown_str}\n`;
-        markdown_str_with_added_newline.should.eql(swagger_api_md_str);
+      });
+
+    });
+
+    describe('with body parameter having a schema', () => {
+      let path_api_spec;
+      let swagger_api_md_str;
+
+      beforeEach(() => {
+        path_api_spec = fixtures.loadSwaggerSpec('path/post-with-params');
+      });
+
+      beforeEach(() => {
+        swagger_api_md_str = fixtures.loadSwaggerSpecMarkdown('path/post-with-params.md');
+      });
+
+      it('should include schema definition in result', () => {
+        const key = Object.keys(path_api_spec)[0];
+        const markdown_str = generator.generatePath(key, path_api_spec[key]);
+        markdown_str.should.eql(swagger_api_md_str);
       });
 
     });

--- a/test/unit/path-generator-test.js
+++ b/test/unit/path-generator-test.js
@@ -14,13 +14,13 @@ describe('test/unit/path-generator-test.js', () => {
       });
 
       beforeEach(() => {
-        // TODO: Strip trailing newline here instead
         swagger_api_md_str = fixtures.loadSwaggerSpecMarkdown('path/mixed-properties.md');
       });
 
       it('should render markdown and omit unspecified data, e.g. descriptions, schemas', () => {
         const key = Object.keys(path_api_spec)[0];
         const markdown_str = generator.generatePath(key, path_api_spec[key]);
+        markdown_str.should.eql(swagger_api_md_str);
         const markdown_str_with_added_newline = `${markdown_str}\n`;
         markdown_str_with_added_newline.should.eql(swagger_api_md_str);
       });

--- a/test/unit/swagger-converter-test.js
+++ b/test/unit/swagger-converter-test.js
@@ -38,7 +38,7 @@ describe('test/unit/swagger-converter-test.js', () => {
 
         it('should return contents of a valid .md file', () => {
           const markdown_str = converter.convertToMarkdown(swagger_api_spec, responseProvider);
-          markdown_str.should.eql(swagger_api_md_str);
+          markdown_str.trim().should.eql(swagger_api_md_str);
         });
 
       });

--- a/test/unit/type-picker-test.js
+++ b/test/unit/type-picker-test.js
@@ -47,6 +47,23 @@ describe('test/unit/type-picker-test.js', () => {
 
     });
 
+    describe('with param having schema with type', () => {
+      let param;
+
+      beforeEach(() => {
+        param = {
+          schema: {
+            type: 'object',
+          },
+        };
+      });
+
+      it('should return type of schema', () => {
+        type_picker.extractType(param).should.eql('object');
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
**Depends on #5 to be merged first.**

**Example:**

---

``` diff
### POST /pets

Creates a new pet

**Parameters**

- - body: body (object) - Params for new pet
+ - body: body (object) - Params for new pet
+  - name (string)
```
