### PR TITLE
fix: Do not show param description if not defined

### DIFF
--- a/src/generators/path-generator.js
+++ b/src/generators/path-generator.js
@@ -46,7 +46,11 @@ function generateParameters(params) {
   }
   const param_list_str = params.map(param => {
     const param_type = type_picker.extractType(param);
-    let value = `- ${param.in}: ${param.name} (${param_type}) - ${param.description}`;
+    let value = `- ${param.in}: ${param.name} (${param_type})`;
+
+    if (param.description) {
+      value += ` - ${param.description}`;
+    }
 
     if (!param.required) {
       value += ' (optional)';

--- a/test-util/fixtures/markdown/path/mixed-properties.md
+++ b/test-util/fixtures/markdown/path/mixed-properties.md
@@ -28,7 +28,7 @@ deletes a single pet based on the ID supplied
 
 **Parameters**
 
-- path: id (integer) - ID of pet to delete
+- path: id (integer)
 
 #### Response: 204
 

--- a/test-util/fixtures/swagger/path/mixed-properties.json
+++ b/test-util/fixtures/swagger/path/mixed-properties.json
@@ -35,7 +35,6 @@
         {
           "name": "id",
           "in": "path",
-          "description": "ID of pet to delete",
           "required": true,
           "type": "integer",
           "format": "int64"


### PR DESCRIPTION
fix: Do not show param description if not defined

Previously displayed `- undefined` after each path param.
