### PR TITLE
Generate table of contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   },
   "homepage": "https://github.com/springworks/swagger-md#readme",
   "dependencies": {
-    "babel-runtime": "6.3.19"
+    "babel-runtime": "6.3.19",
+    "toc-md": "0.2.0"
   },
   "devDependencies": {
-    "@springworks/test-harness": "1.2.3",
+    "@springworks/test-harness": "1.3.1",
     "babel-cli": "6.4.5",
     "babel-core": "6.4.5",
     "babel-eslint": "4.1.7",

--- a/src/generators/intro-generator.js
+++ b/src/generators/intro-generator.js
@@ -4,9 +4,11 @@ const api = {
     const api_info = swagger_spec.info;
     const header = `# ${api_info.title}, version ${api_info.version}`;
     const base_url = `Base URL: ${swagger_spec.schemes.join('|')}://${swagger_spec.host}${swagger_spec.basePath}`;
+    const toc_location = '<!-- TOC -->\n<!-- TOC END -->';
     return [
       header,
       base_url,
+      toc_location,
     ].join('\n\n');
   },
 

--- a/src/generators/toc-generator.js
+++ b/src/generators/toc-generator.js
@@ -1,0 +1,26 @@
+import toc_md from 'toc-md';
+
+
+const api = {
+
+  generateTableOfContents(md_string) {
+    let error = null;
+    let result = null;
+    let sync = false;
+    toc_md.insert(md_string, { maxDepth: 3 }, (err, str) => {
+      error = err;
+      result = str;
+      sync = true;
+    });
+    if (!sync) {
+      throw new Error('Expected toc-md callback to be invoked synchronously');
+    }
+    if (error) {
+      throw error;
+    }
+    return result;
+  },
+
+};
+
+export default api;

--- a/src/swagger-converter.js
+++ b/src/swagger-converter.js
@@ -1,6 +1,7 @@
 import intro_generator from './generators/intro-generator';
 import path_generator from './generators/path-generator';
 import definition_generator from './generators/definition-generator';
+import toc_generator from './generators/toc-generator';
 
 function convertPaths(paths, opt_response_example_provider) {
   return [
@@ -31,8 +32,8 @@ const api = {
     let components = [result.intro];
     components = components.concat(result.paths);
     components = components.concat(result.definitions);
-    const joined = components.join('\n\n');
-    return `${joined}\n`;
+    const joined = `${components.join('\n\n')}\n`;
+    return toc_generator.generateTableOfContents(joined);
   },
 };
 

--- a/test-util/fixtures/markdown/pet-store-with-response-examples.md
+++ b/test-util/fixtures/markdown/pet-store-with-response-examples.md
@@ -2,6 +2,19 @@
 
 Base URL: http://petstore.swagger.io/api
 
+<!-- TOC -->
+- [Endpoints](#endpoints)
+  - [GET /pets](#get-pets)
+  - [POST /pets](#post-pets)
+  - [GET /pets/{id}](#get-petsid)
+  - [DELETE /pets/{id}](#delete-petsid)
+- [Definitions](#definitions)
+  - [Pet](#pet)
+  - [NewPet](#newpet)
+  - [Error](#error)
+
+<!-- TOC END -->
+
 ## Endpoints
 
 ### GET /pets

--- a/test/unit/toc-generator-test.js
+++ b/test/unit/toc-generator-test.js
@@ -1,0 +1,51 @@
+import toc_md from 'toc-md';
+import autorestoredSandbox from '@springworks/test-harness/autorestored-sandbox';
+import fixtures from '../../test-util/fixtures';
+import generator from '../../src/generators/toc-generator';
+
+describe('test/unit/toc-generator-test.js', () => {
+
+  let md_fixture_with_toc;
+  let md_fixture_without_toc;
+
+  beforeEach(done => {
+    md_fixture_with_toc = fixtures.loadSwaggerSpecMarkdown('pet-store-with-response-examples.md');
+    toc_md.clean(md_fixture_with_toc, (err, str) => {
+      if (err) {
+        setImmediate(done, err);
+        return;
+      }
+      md_fixture_without_toc = str;
+      done();
+    });
+  });
+
+  describe('generateTableOfContents', () => {
+
+    describe('with a markdown string without a TOC', () => {
+
+      it('should return the markdown with a TOC inserted', () => {
+        const markdown_str = generator.generateTableOfContents(md_fixture_without_toc);
+        markdown_str.should.eql(md_fixture_with_toc);
+      });
+
+    });
+
+    describe('if toc-md changes to invoke the callback async', () => {
+      const sandbox = autorestoredSandbox();
+
+      beforeEach(() => {
+        sandbox.stub(toc_md, 'insert').yieldsAsync();
+      });
+
+      it('should throw an error if the callback is not synchronous', () => {
+        (() => {
+          generator.generateTableOfContents(md_fixture_without_toc);
+        }).should.throw('Expected toc-md callback to be invoked synchronously');
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
See the [markdown fixture](https://github.com/Springworks/swagger-md/blob/feature/table-of-contents/test-util/fixtures/markdown/pet-store-with-response-examples.md) for an example of the generated table of contents.
