### PR TITLE
Link to definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "NODE_ENV=test istanbul cover _mocha"
   },
   "dependencies": {
+    "markdown-link": "0.1.1",
     "toc-md": "0.2.0"
   },
   "devDependencies": {

--- a/src/generators/schema-generator.js
+++ b/src/generators/schema-generator.js
@@ -1,3 +1,4 @@
+import createMarkdownLink from 'markdown-link';
 import type_picker from './type-picker';
 
 function extractDefinitionName(ref) {
@@ -9,7 +10,7 @@ function propertyListItem(property_key, prop, required_properties) {
   let value;
 
   if (property_key === '$ref') {
-    value = `(${extractDefinitionName(prop)})`;
+    value = linkToHeader(extractDefinitionName(prop));
   }
   else {
     const type = type_picker.extractType(prop);
@@ -27,12 +28,17 @@ function propertyListItem(property_key, prop, required_properties) {
   return `- ${value}`;
 }
 
+function linkToHeader(header) {
+  const slug = header.replace(/\s/g, '-').replace(/[^a-z0-9_\-]/gi, '').toLowerCase();
+  return createMarkdownLink(header, `#${slug}`);
+}
+
 const api = {
 
   createSchemaList(schema, item_indent = '  ') {
     if (schema.$ref) {
       const definition_name = extractDefinitionName(schema.$ref);
-      return `- (${definition_name})`;
+      return `- ${linkToHeader(definition_name)}`;
     }
 
     if (schema.allOf) {

--- a/test-util/fixtures/markdown/path/mixed-properties.md
+++ b/test-util/fixtures/markdown/path/mixed-properties.md
@@ -12,7 +12,7 @@ pet response
 
 **Schema**
 
-- (Pet)
+- [Pet](#pet)
 
 #### Response: default
 
@@ -20,7 +20,7 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)
 
 ### DELETE /pets/{id}
 
@@ -44,4 +44,4 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)

--- a/test-util/fixtures/markdown/path/post-with-params.md
+++ b/test-util/fixtures/markdown/path/post-with-params.md
@@ -13,7 +13,7 @@ pet response
 
 **Schema**
 
-- (Pet)
+- [Pet](#pet)
 
 #### Response: default
 
@@ -21,4 +21,4 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)

--- a/test-util/fixtures/markdown/pet-store-with-response-examples.md
+++ b/test-util/fixtures/markdown/pet-store-with-response-examples.md
@@ -33,7 +33,7 @@ pet response
 **Schema**
 
 - (array)
-  - (Pet)
+  - [Pet](#pet)
 
 #### Response: default
 
@@ -41,7 +41,7 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)
 
 #### Example response
 
@@ -65,7 +65,7 @@ pet response
 
 **Schema**
 
-- (Pet)
+- [Pet](#pet)
 
 #### Response: default
 
@@ -73,7 +73,7 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)
 
 #### Example response
 
@@ -97,7 +97,7 @@ pet response
 
 **Schema**
 
-- (Pet)
+- [Pet](#pet)
 
 #### Response: default
 
@@ -105,7 +105,7 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)
 
 #### Example response
 
@@ -137,7 +137,7 @@ unexpected error
 
 **Schema**
 
-- (Error)
+- [Error](#error)
 
 #### Example response
 
@@ -154,7 +154,7 @@ unexpected error
 **Schema**
 
 - (object) All of:
-  - (NewPet)
+  - [NewPet](#newpet)
   - (object)
     - id (integer)
 

--- a/test-util/fixtures/markdown/schema/all-of.md
+++ b/test-util/fixtures/markdown/schema/all-of.md
@@ -1,4 +1,4 @@
 - (object) All of:
-  - (NewPet)
+  - [NewPet](#newpet)
   - (object)
     - id (integer)

--- a/test/unit/generators/schema-generator-test.js
+++ b/test/unit/generators/schema-generator-test.js
@@ -41,7 +41,7 @@ describe('test/unit/generators/schema-generator-test.js', () => {
       });
 
       it('should return a list with a single item; the name of the definition', () => {
-        generator.createSchemaList(schema).should.eql('- (Pet)');
+        generator.createSchemaList(schema).should.eql('- [Pet](#pet)');
       });
 
     });
@@ -60,7 +60,7 @@ describe('test/unit/generators/schema-generator-test.js', () => {
 
       it('should return a list with the properties', () => {
         const expected = '- (array)\n' +
-            '  - (Pet)';
+            '  - [Pet](#pet)';
         generator.createSchemaList(schema).should.eql(expected);
       });
 


### PR DESCRIPTION
When referencing the name of a definition, the name will now be linked to the header of that definition.

For example:

```
#### Response: 200

Pet response

**Schema**

- (array)
  - [Pet](#pet)
```
