### PR TITLE
fix: Allow `basePath` to be undefined

### DIFF
--- a/src/generators/intro-generator.js
+++ b/src/generators/intro-generator.js
@@ -3,7 +3,7 @@ const api = {
   generateApiIntro(swagger_spec) {
     const api_info = swagger_spec.info;
     const header = `# ${api_info.title}, version ${api_info.version}`;
-    const base_url = `Base URL: ${swagger_spec.schemes.join('|')}://${swagger_spec.host}${swagger_spec.basePath}`;
+    const base_url = `Base URL: ${swagger_spec.schemes.join('|')}://${swagger_spec.host}${swagger_spec.basePath || ''}`;
     const toc_location = '<!-- TOC -->\n<!-- TOC END -->';
     return [
       header,


### PR DESCRIPTION
fix: Allow `basePath` to be undefined

Ensures that intro is generated properly even when `basePath` is unspecified.
