### PR TITLE
fix: default definitions to an empty object

### DIFF
--- a/src/swagger-converter.js
+++ b/src/swagger-converter.js
@@ -26,7 +26,7 @@ const api = {
     const result = {
       intro: intro_generator.generateApiIntro(swagger_spec),
       paths: convertPaths(swagger_spec.paths, opt_response_example_provider),
-      definitions: convertDefinitions(swagger_spec.definitions),
+      definitions: convertDefinitions(swagger_spec.definitions || {}),
     };
 
     let components = [result.intro];


### PR DESCRIPTION
When the swagger spec does not contain any definitions it will fall back to an empty object.
