### PR TITLE
feat: support deprecated and externalDocs

### DIFF
--- a/src/generators/path-generator.js
+++ b/src/generators/path-generator.js
@@ -11,7 +11,10 @@ function generateMethods(path_key, path, opt_response_example_provider) {
     const method_spec = path[method];
     return [
       `### ${method.toUpperCase()} ${path_key}`,
+      deprecationWarning(method_spec),
       method_spec.description,
+      externalDocs(method_spec, 'description'),
+      externalDocs(method_spec, 'url'),
       generateParameters(method_spec.parameters),
       generateResponses(method_spec.responses),
       generateExampleResponse(path_key, method, opt_response_example_provider),
@@ -82,6 +85,14 @@ function generateExampleResponse(path_key, method, opt_response_example_provider
     '#### Example response',
     example_response,
   ].join('\n\n');
+}
+
+function deprecationWarning(spec) {
+  return spec.deprecated ? '> :warning: **deprecated**' : null;
+}
+
+function externalDocs(spec, key) {
+  return spec.externalDocs && spec.externalDocs[key] ? spec.externalDocs[key] : null;
 }
 
 const api = {

--- a/test-util/fixtures/markdown/path/mixed-properties.md
+++ b/test-util/fixtures/markdown/path/mixed-properties.md
@@ -24,7 +24,13 @@ unexpected error
 
 ### DELETE /pets/{id}
 
+> :warning: **deprecated**
+
 deletes a single pet based on the ID supplied
+
+More info on deleting pets
+
+https://example.com/more-info
 
 **Parameters**
 

--- a/test-util/fixtures/swagger/path/mixed-properties.json
+++ b/test-util/fixtures/swagger/path/mixed-properties.json
@@ -30,6 +30,11 @@
     },
     "delete": {
       "description": "deletes a single pet based on the ID supplied",
+      "deprecated": true,
+      "externalDocs": {
+        "description": "More info on deleting pets",
+        "url": "https://example.com/more-info"
+      },
       "operationId": "deletePet",
       "parameters": [
         {


### PR DESCRIPTION
Add support for the path properties `deprecated` and `externalDocs`
