### PR TITLE
feat: mark deprecated in table of contents

### DIFF
--- a/src/generators/toc-generator.js
+++ b/src/generators/toc-generator.js
@@ -16,7 +16,8 @@ const api = {
       const methods = paths[path];
       Object.keys(methods).forEach(method => {
         const header = `${method.toUpperCase()} ${path}`;
-        toc_array.push(`  - ${linkToHeader(header)}`);
+        const deprecated = methods[method].deprecated ? ' _`deprecated`_' : '';
+        toc_array.push(`  - ${linkToHeader(header)}${deprecated}`);
       });
     });
 

--- a/test-util/fixtures/markdown/pet-store-toc.md
+++ b/test-util/fixtures/markdown/pet-store-toc.md
@@ -3,7 +3,7 @@
   - [GET /pets](#get-pets)
   - [POST /pets](#post-pets)
   - [GET /pets/{id}](#get-petsid)
-  - [DELETE /pets/{id}](#delete-petsid)
+  - [DELETE /pets/{id}](#delete-petsid) _`deprecated`_
 - [Definitions](#definitions)
   - [Pet](#pet)
   - [NewPet](#newpet)

--- a/test-util/fixtures/markdown/pet-store-with-response-examples.md
+++ b/test-util/fixtures/markdown/pet-store-with-response-examples.md
@@ -7,7 +7,7 @@ Base URL: http://petstore.swagger.io/api
   - [GET /pets](#get-pets)
   - [POST /pets](#post-pets)
   - [GET /pets/{id}](#get-petsid)
-  - [DELETE /pets/{id}](#delete-petsid)
+  - [DELETE /pets/{id}](#delete-petsid) _`deprecated`_
 - [Definitions](#definitions)
   - [Pet](#pet)
   - [NewPet](#newpet)
@@ -116,6 +116,8 @@ unexpected error
 ```
 
 ### DELETE /pets/{id}
+
+> :warning: **deprecated**
 
 deletes a single pet based on the ID supplied
 

--- a/test-util/fixtures/swagger/pet-store.json
+++ b/test-util/fixtures/swagger/pet-store.json
@@ -130,6 +130,7 @@
         }
       },
       "delete": {
+        "deprecated": true,
         "description": "deletes a single pet based on the ID supplied",
         "operationId": "deletePet",
         "parameters": [


### PR DESCRIPTION
Show a little _`deprecated`_ next to any deprecated endpoint in the table of contents
