### PR TITLE
Render request params as tables

### DIFF
--- a/src/generators/md-table.js
+++ b/src/generators/md-table.js
@@ -1,0 +1,36 @@
+export default function createTable(header, records) {
+  const hd = header.filter(key => records.some(rec => toStr(rec[key])));
+  const widths = maxWidths(hd, records);
+  const lines = [
+    row(hd, widths, pad),
+    row(hd, widths, (key, width) => repeat('-', width + 2)),
+  ];
+  records.forEach(rec => {
+    lines.push(row(hd, widths, (key, width) => pad(toStr(rec[key]), width)));
+  });
+  return lines.join('\n');
+}
+
+function row(hd, widths, fn) {
+  return `|${hd.map((key, i) => fn(key, widths[i])).join('|')}|`;
+}
+
+function maxWidths(hd, records) {
+  return hd.map(key => records.map(rec => toStr(rec[key]).length).reduce(max, key.length));
+}
+
+function max(a, b) {
+  return a > b ? a : b;
+}
+
+function pad(str, len) {
+  return ` ${str} ${repeat(' ', len - str.length)}`;
+}
+
+function repeat(chr, len) {
+  return new Array(len + 1).join(chr);
+}
+
+function toStr(val) {
+  return val === undefined || val === null ? '' : String(val);
+}

--- a/src/generators/request-parameters-table.js
+++ b/src/generators/request-parameters-table.js
@@ -1,0 +1,98 @@
+import type_picker from './type-picker';
+import linkToHeader from './link-to-header';
+import createTable from './md-table';
+
+
+export default function createParametersTable(params) {
+  if (!params.length) {
+    return undefined;
+  }
+
+  return createTable([
+    'in',
+    'name',
+    'type',
+    'required',
+    'description',
+    'pattern',
+    'range',
+    'default',
+    'unique',
+    'multiple_of',
+  ], params.map(param => ({
+    in: param.in,
+    name: param.name,
+    type: formatParamType(param),
+    required: !!param.required,
+    description: param.description,
+    pattern: formatCode(param.pattern, false),
+    range: formatParamRange(param),
+    default: formatCode(param.default, true),
+    unique: param.uniqueItems,
+    multiple_of: param.multipleOf,
+  })));
+}
+
+
+function formatParamType(param) {
+  if (param.schema) {
+    if (param.schema.$ref) {
+      return linkToHeader(type_picker.extractType(param.schema));
+    }
+    return '';
+  }
+  let type = param.type;
+  if (!type) {
+    return '';
+  }
+  if (type === 'array') {
+    type = `${type}, ${param.collectionFormat || 'csv'}`;
+    if (param.items) {
+      type = `${type} of ${formatParamType(param.items)}`;
+    }
+  }
+  if (param.format) {
+    type = `${type}, ${param.format}`;
+  }
+  if (type === 'string' && param.enum) {
+    type = `${type}: ${param.enum.join(', ')}`;
+  }
+  return type;
+}
+
+function formatParamRange(param) {
+  let r = '';
+  if (typeof param.minimum === 'number') {
+    r = `${param.exclusiveMinimum ? '>' : '>='} ${param.minimum}`;
+  }
+  if (typeof param.maximum === 'number') {
+    r += `${r ? ' && ' : ''}${param.exclusiveMaximum ? '<' : '<='} ${param.maximum}`;
+  }
+  if (!r) {
+    if (typeof param.minLength === 'number') {
+      r = `>= ${param.minLength}`;
+    }
+    if (typeof param.maxLength === 'number') {
+      r += `${r ? ' && ' : ''}<= ${param.maxLength}`;
+    }
+  }
+  if (!r) {
+    if (typeof param.minItems === 'number') {
+      r = `>= ${param.minItems}`;
+    }
+    if (typeof param.maxItems === 'number') {
+      r += `${r ? ' && ' : ''}<= ${param.maxItems}`;
+    }
+  }
+  return r ? `\`${r}\`` : '';
+}
+
+function formatCode(value, as_json) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (as_json) {
+    return `\`${JSON.stringify(value)}\``;
+  }
+  return `\`${value}\``;
+}

--- a/test-util/fixtures/markdown/path/mixed-properties.md
+++ b/test-util/fixtures/markdown/path/mixed-properties.md
@@ -4,7 +4,9 @@ Returns a user based on a single ID, if the user does not have access to the pet
 
 **Parameters**
 
-- path: id (integer) - ID of pet to fetch
+| in   | name | type           | required | description        |
+|------|------|----------------|----------|--------------------|
+| path | id   | integer, int64 | true     | ID of pet to fetch |
 
 #### Response: 200
 
@@ -34,7 +36,9 @@ https://example.com/more-info
 
 **Parameters**
 
-- path: id (integer)
+| in   | name | type           | required |
+|------|------|----------------|----------|
+| path | id   | integer, int64 | true     |
 
 #### Response: 204
 

--- a/test-util/fixtures/markdown/path/post-with-params.md
+++ b/test-util/fixtures/markdown/path/post-with-params.md
@@ -4,7 +4,13 @@ Creates a new pet
 
 **Parameters**
 
-- body: body (object) - Params for new pet
+| in   | name | required | description        |
+|------|------|----------|--------------------|
+| body | body | true     | Params for new pet |
+
+**Request Body**
+
+- (object)
   - name (string)
 
 #### Response: 201

--- a/test-util/fixtures/markdown/pet-store-with-response-examples.md
+++ b/test-util/fixtures/markdown/pet-store-with-response-examples.md
@@ -20,8 +20,10 @@ Returns all pets from the system that the user has access to
 
 **Parameters**
 
-- query: tags (array) - tags to filter by (optional)
-- query: limit (integer) - maximum number of results to return (optional)
+| in    | name  | type                                                          | required | description                         | range           | default | unique |
+|-------|-------|---------------------------------------------------------------|----------|-------------------------------------|-----------------|---------|--------|
+| query | tags  | array, csv of string: clueless, lazy, adventurous, aggressive | false    | tags to filter by                   | `>= 0 && <= 3`  |         | true   |
+| query | limit | integer, int32                                                | false    | maximum number of results to return | `> 0 && <= 200` | `20`    |        |
 
 #### Response: 200
 
@@ -54,7 +56,9 @@ Creates a new pet in the store.  Duplicates are allowed
 
 **Parameters**
 
-- body: pet (NewPet) - Pet to add to the store
+| in   | name | type              | required | description             |
+|------|------|-------------------|----------|-------------------------|
+| body | pet  | [NewPet](#newpet) | true     | Pet to add to the store |
 
 #### Response: 200
 
@@ -86,7 +90,9 @@ Returns a user based on a single ID, if the user does not have access to the pet
 
 **Parameters**
 
-- path: id (integer) - ID of pet to fetch
+| in   | name | type           | required | description        |
+|------|------|----------------|----------|--------------------|
+| path | id   | integer, int64 | true     | ID of pet to fetch |
 
 #### Response: 200
 
@@ -120,7 +126,9 @@ deletes a single pet based on the ID supplied
 
 **Parameters**
 
-- path: id (integer) - ID of pet to delete
+| in   | name | type           | required | description         |
+|------|------|----------------|----------|---------------------|
+| path | id   | integer, int64 | true     | ID of pet to delete |
 
 #### Response: 204
 

--- a/test-util/fixtures/swagger/pet-store.json
+++ b/test-util/fixtures/swagger/pet-store.json
@@ -40,8 +40,17 @@
             "type": "array",
             "collectionFormat": "csv",
             "items": {
-              "type": "string"
-            }
+              "type": "string",
+              "enum": [
+                "clueless",
+                "lazy",
+                "adventurous",
+                "aggressive"
+              ]
+            },
+            "minItems": 0,
+            "maxItems": 3,
+            "uniqueItems": true
           },
           {
             "name": "limit",
@@ -49,7 +58,11 @@
             "description": "maximum number of results to return",
             "required": false,
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "maximum": 200,
+            "default": 20
           }
         ],
         "responses": {

--- a/test/unit/md-table-test.js
+++ b/test/unit/md-table-test.js
@@ -1,0 +1,73 @@
+import createTable from '../../src/generators/md-table';
+
+describe('test/unit/md-table-test.js', () => {
+
+  describe('createTable', () => {
+
+    describe('with simple headers and records', () => {
+
+      it('should return a markdown table', () => {
+        createTable(['a', 'b', 'c'], [
+          { a: 1, b: 2, c: 3 },
+          { a: 4, b: 5, c: 6 },
+        ]).should.equal(join([
+          '| a | b | c |',
+          '|---|---|---|',
+          '| 1 | 2 | 3 |',
+          '| 4 | 5 | 6 |',
+        ]));
+      });
+
+    });
+
+    describe('when one of the headers is never used', () => {
+
+      it('should not include the column', () => {
+        createTable(['a', 'b', 'c'], [
+          { a: 1, b: undefined, c: 3 },
+          { a: 4, b: undefined, c: 6 },
+        ]).should.equal(join([
+          '| a | c |',
+          '|---|---|',
+          '| 1 | 3 |',
+          '| 4 | 6 |',
+        ]));
+      });
+
+    });
+
+    describe('alignment', () => {
+
+      it('should align to a wide header', () => {
+        createTable(['a', 'b', 'wide_header'], [
+          { a: 1, b: 2, wide_header: 3 },
+          { a: 4, b: 5, wide_header: 6 },
+        ]).should.equal(join([
+          '| a | b | wide_header |',
+          '|---|---|-------------|',
+          '| 1 | 2 | 3           |',
+          '| 4 | 5 | 6           |',
+        ]));
+      });
+
+      it('should align to a wide record value', () => {
+        createTable(['a', 'b', 'wide_header'], [
+          { a: 'lots of text', b: 2, wide_header: 3 },
+          { a: 4, b: 'another long string', wide_header: 6 },
+        ]).should.equal(join([
+          '| a            | b                   | wide_header |',
+          '|--------------|---------------------|-------------|',
+          '| lots of text | 2                   | 3           |',
+          '| 4            | another long string | 6           |',
+        ]));
+      });
+
+    });
+
+  });
+
+});
+
+function join(lines) {
+  return lines.join('\n');
+}


### PR DESCRIPTION
Request parameters are rendered as a markdown table.

If a body param is specified and it has a schema that doesn’t just refer to a model, then a _Request Body_ section is added where the body schema is listed in details.

The parameters table can include the following columns: in, name, type, required, description, pattern, range, default, unique, multiple_of.

The type column includes format and enum values. If the type is “array” then it can also include type info about array items, e.g. `array of integer`.

The range column will include min and max. This can refer to a numeric value, string length or number of items in an array.
