### PR TITLE
feat: include type of range in range format

### DIFF
--- a/src/generators/request-parameters-table.js
+++ b/src/generators/request-parameters-table.js
@@ -61,30 +61,26 @@ function formatParamType(param) {
 }
 
 function formatParamRange(param) {
+  return formatRange('number', param.minimum, param.maximum, param.exclusiveMinimum, param.exclusiveMaximum) ||
+         formatRange('length', param.minLength, param.maxLength, false, false) ||
+         formatRange('items', param.minItems, param.maxItems, false, false);
+}
+
+function formatRange(type, min, max, exclusive_min, exclusive_max) {
+  const has_min = typeof min === 'number';
+  const has_max = typeof max === 'number';
+  if (!has_min && !has_max) {
+    return undefined;
+  }
   let r = '';
-  if (typeof param.minimum === 'number') {
-    r = `${param.exclusiveMinimum ? '>' : '>='} ${param.minimum}`;
+  if (has_min) {
+    r = `${min} ${exclusive_min ? '<' : '<='} `;
   }
-  if (typeof param.maximum === 'number') {
-    r += `${r ? ' && ' : ''}${param.exclusiveMaximum ? '<' : '<='} ${param.maximum}`;
+  r += type;
+  if (has_max) {
+    r += ` ${exclusive_max ? '<' : '<='} ${max}`;
   }
-  if (!r) {
-    if (typeof param.minLength === 'number') {
-      r = `>= ${param.minLength}`;
-    }
-    if (typeof param.maxLength === 'number') {
-      r += `${r ? ' && ' : ''}<= ${param.maxLength}`;
-    }
-  }
-  if (!r) {
-    if (typeof param.minItems === 'number') {
-      r = `>= ${param.minItems}`;
-    }
-    if (typeof param.maxItems === 'number') {
-      r += `${r ? ' && ' : ''}<= ${param.maxItems}`;
-    }
-  }
-  return r ? `\`${r}\`` : '';
+  return `\`${r}\``;
 }
 
 function formatCode(value, as_json) {

--- a/test-util/fixtures/markdown/pet-store-with-response-examples.md
+++ b/test-util/fixtures/markdown/pet-store-with-response-examples.md
@@ -20,10 +20,11 @@ Returns all pets from the system that the user has access to
 
 **Parameters**
 
-| in    | name  | type                                                          | required | description                         | range           | default | unique |
-|-------|-------|---------------------------------------------------------------|----------|-------------------------------------|-----------------|---------|--------|
-| query | tags  | array, csv of string: clueless, lazy, adventurous, aggressive | false    | tags to filter by                   | `>= 0 && <= 3`  |         | true   |
-| query | limit | integer, int32                                                | false    | maximum number of results to return | `> 0 && <= 200` | `20`    |        |
+| in    | name   | type                                                          | required | description                         | range               | default | unique |
+|-------|--------|---------------------------------------------------------------|----------|-------------------------------------|---------------------|---------|--------|
+| query | tags   | array, csv of string: clueless, lazy, adventurous, aggressive | false    | tags to filter by                   | `0 <= items <= 3`   |         | true   |
+| query | limit  | integer, int32                                                | false    | maximum number of results to return | `0 < number <= 200` | `20`    |        |
+| query | offset | integer, int32                                                | false    | results offset                      | `0 <= number`       |         |        |
 
 #### Response: 200
 

--- a/test-util/fixtures/swagger/pet-store.json
+++ b/test-util/fixtures/swagger/pet-store.json
@@ -63,6 +63,15 @@
             "exclusiveMinimum": true,
             "maximum": 200,
             "default": 20
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "results offset",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {


### PR DESCRIPTION
When a parameter is limited to a min/max value, a range column is included. Min and max can refer to a numeric param, the length of a string param or the number of items in an array param.

To make this less confusing the range is now formated like this:

```
{min} <= number <= {max}
{min} <= length <= {max}
{min} <= items <= {max}
```

Only one has to be specified

```
{min} <= number
number <= {max}
```

Numbers can be exclusive

```
{min} < number < {max}
```
